### PR TITLE
Update django.po

### DIFF
--- a/diacamma/payoff/locale/fr/LC_MESSAGES/django.po
+++ b/diacamma/payoff/locale/fr/LC_MESSAGES/django.po
@@ -25,7 +25,7 @@ msgstr "Règlement Diacamma"
 
 #: editors.py:112
 msgid "payoff null!"
-msgstr "réglement vide!"
+msgstr "règlement vide !"
 
 #: editors.py:127 models.py:403
 msgid "No-valid selection!"
@@ -57,7 +57,7 @@ msgstr "total payé"
 
 #: models.py:72 models.py:76
 msgid "rest to pay"
-msgstr "rest dû"
+msgstr "restant dû"
 
 #: models.py:79 models.py:80 models.py:247
 msgid "supporting"
@@ -69,7 +69,7 @@ msgstr "aucun tiers sélectionné"
 
 #: models.py:128 models.py:147 models.py:152
 msgid "third has not correct account"
-msgstr "le tiers n'a pas de compte correcte"
+msgstr "le tiers n'a pas de compte correct"
 
 #: models.py:138
 msgid "date not include in current fiscal year"
@@ -93,7 +93,7 @@ msgstr "compte bancaire"
 
 #: models.py:240
 msgid "bank accounts"
-msgstr "comptes bancaire"
+msgstr "comptes bancaires"
 
 #: models.py:248 models.py:466 models.py:729 views_deposit.py:148
 msgid "date"
@@ -141,7 +141,7 @@ msgstr "écriture"
 
 #: models.py:260
 msgid "bank fee"
-msgstr "frais bancaire"
+msgstr "frais bancaires"
 
 #: models.py:265
 msgid "value"
@@ -149,29 +149,29 @@ msgstr "valeur"
 
 #: models.py:280
 msgid "an entry associated to this payoff is closed!"
-msgstr "une écriture associée à ce réglement est clôturée!"
+msgstr "une écriture associée à ce règlement est clôturée !"
 
 #: models.py:310 models.py:431 models.py:763
 #, python-format
 msgid "payoff for %s"
-msgstr "réglement de %s"
+msgstr "règlement de %s"
 
 #: models.py:330
 msgid "account is not defined!"
-msgstr "le compte n'est pas défini!"
+msgstr "le compte n'est pas défini !"
 
 #: models.py:433 models.py:765
 #, python-format
 msgid "payoff for %d multi-pay"
-msgstr "réglement de %d factures"
+msgstr "règlement de %d factures"
 
 #: models.py:455 models.py:536
 msgid "payoff"
-msgstr "réglement"
+msgstr "règlement"
 
 #: models.py:456
 msgid "payoffs"
-msgstr "réglements"
+msgstr "règlements"
 
 #: models.py:462 models.py:730
 msgid "status"
@@ -200,7 +200,7 @@ msgstr "nombre"
 #: models.py:501
 #, python-format
 msgid "Remove of %s impossible!"
-msgstr "Supression de %s impossible!"
+msgstr "Supression de %s impossible !"
 
 #: models.py:504
 msgid "To Close"
@@ -296,7 +296,7 @@ msgstr "transactions bancaires"
 
 #: models.py:788
 msgid "payoff-bankcharges-account"
-msgstr "compte de frais bancaire"
+msgstr "compte de frais bancaires"
 
 #: models.py:789
 msgid "payoff-cash-account"
@@ -323,15 +323,15 @@ msgstr ""
 
 #: views.py:62
 msgid "Add payoff"
-msgstr "Ajouter un réglement"
+msgstr "Ajouter un règlement"
 
 #: views.py:63
 msgid "Modify payoff"
-msgstr "Modifier un réglement"
+msgstr "Modifier un règlement"
 
 #: views.py:93
 msgid "Delete payoff"
-msgstr "Supprimer un réglement"
+msgstr "Supprimer un règlement"
 
 #: views.py:96
 msgid "change"
@@ -343,7 +343,7 @@ msgstr "Sélection d'un tiers"
 
 #: views.py:119
 msgid "Filtrer by contact"
-msgstr "Filtre par contact"
+msgstr "Filtrer par contact"
 
 #: views.py:135 views_deposit.py:161
 msgid "select"
@@ -383,7 +383,7 @@ msgstr "Moyens de paiement"
 
 #: views_conf.py:33
 msgid "Management of parameters and configuration of payoff"
-msgstr "Gestion des paramètres et des configuration du règlement"
+msgstr "Gestion des paramètres et de configuration du règlement"
 
 #: views_conf.py:38
 msgid "Payoff configuration"
@@ -427,7 +427,7 @@ msgstr "Supprimer un moyen de paiement"
 
 #: views_conf.py:104
 msgid "Payoff"
-msgstr "Réglement"
+msgstr "Règlement"
 
 #: views_conf.py:139
 msgid "Configuration of payoff parameters"
@@ -436,14 +436,14 @@ msgstr "Definissez vos paramètrages de règlement"
 #: views_conf.py:142
 msgid "Configuration of bank account"
 msgstr ""
-"Ajoutez vos comptes bancaires.{[br/]}Ils apparaitrons comme choix de "
-"réglement."
+"Ajoutez vos comptes bancaires.{[br/]}Ils apparaitront comme choix de "
+"règlement."
 
 #: views_conf.py:145
 msgid "Configuration of payment method"
 msgstr ""
-"Ajoutez vos moyens de paiements.{[br/]}Ces choix seront proposés à vos "
-"utilisateurs pour un réglement à distance."
+"Ajoutez vos moyens de paiement.{[br/]}Ces choix seront proposés à vos "
+"utilisateurs pour un règlement à distance."
 
 #: views_deposit.py:23
 msgid "manage deposit of cheque"
@@ -451,11 +451,11 @@ msgstr "gestion des dépôts de chèques"
 
 #: views_deposit.py:41
 msgid "Filter by status"
-msgstr "Filtre par status"
+msgstr "Filtrer par status"
 
 #: views_deposit.py:50
 msgid "Filter by year"
-msgstr "Filtre par exercice"
+msgstr "Filtrer par exercice"
 
 #: views_deposit.py:70
 msgid "Add deposit slip"


### PR DESCRIPTION
Correction de fautes d'orthographe.
En français il faut un espace avant un point d'exclamation, d'interrogation et ":".